### PR TITLE
实现接口请求速率限制

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ SCF意指Serverless Cloud Function 云函数。
 
 API使用参考： [Postman文档](https://documenter.getpostman.com/view/32034983/2sA3BuX9Nc)（施工中）
 
+# 环境变量
+
+- **SCF_REQUEST_LIMIT_WINDOW**: 请求频率窗口期，默认值为5分钟（300000ms）。示例值：1000（1秒）
+- **SCF_REQUEST_LIMIT**: 请求窗口期内，最多全局请求数量，如果超过这个数量会返回429。默认值为100（100个请求）。示例值：1（1个请求）
 
 # API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@hono/node-server": "^1.9.1",
         "hono": "^4.2.2",
+        "hono-rate-limiter": "^0.4.0",
         "protobufjs": "^7.2.6",
         "ts-md5": "^1.3.1"
       },
@@ -90,6 +91,14 @@
       "integrity": "sha512-mDmjBHF6uBNN3TASdAbDCFsN9FLbrlgXyFZkhLEkU7hUgk0+T9hcsUrL/nho4qV+Xk0RDHx7gop4Q1gelZZVRw==",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/hono-rate-limiter": {
+      "version": "0.4.0",
+      "resolved": "https://r.cnpmjs.org/hono-rate-limiter/-/hono-rate-limiter-0.4.0.tgz",
+      "integrity": "sha512-7RWU2HZvxPtfBrvjXKDiQ3F6ZH8k49JhxVkHquUz5UZKjauj5PrP29MvISykThtfpy4mGG6kqxFBHW1ed9wwnA==",
+      "peerDependencies": {
+        "hono": "^4.1.1"
       }
     },
     "node_modules/long": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@hono/node-server": "^1.9.1",
     "hono": "^4.2.2",
+    "hono-rate-limiter": "^0.4.0",
     "protobufjs": "^7.2.6",
     "ts-md5": "^1.3.1"
   },

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,10 +1,26 @@
 import {serve} from '@hono/node-server'
 import {Hono} from 'hono/quick'
 import { cors } from 'hono/cors'
+import { rateLimiter } from "hono-rate-limiter"
 
 const app = new Hono()
 
 app.use('*', cors())
+
+// 全局请求速率限制
+const limiter = rateLimiter({
+  // 5 minutes
+  windowMs: process.env.SCF_REQUEST_LIMIT_WINDOW || 5 * 60 * 1000, 
+  // Limit each IP to 100 requests per `window` (here, per 5 minutes).
+  limit: process.env.SCF_REQUEST_LIMIT || 100, 
+  // draft-6: `RateLimit-*` headers; draft-7: combined `RateLimit` header
+  standardHeaders: "draft-6", 
+  // 唯一key，用于标识一类需要限制的请求。这里写死了，所以所有请求都会被限制
+  keyGenerator: (c) => "global", 
+})
+
+// Apply the rate limiting middleware to all requests.
+app.use(limiter)
 
 import user from "./routes/user.mjs";
 import forum from "./routes/forum.mjs";


### PR DESCRIPTION
目前就实现了`全局`请求速率限制。issues：#1  。我个人进行了一些简单的接口测试，但可能并不全面

### 环境变量

- **SCF_REQUEST_LIMIT_WINDOW**: 请求频率窗口期，默认值为5分钟（300000ms）。示例值：1000（1秒）
- **SCF_REQUEST_LIMIT**: 请求窗口期内，最多全局请求数量，如果超过这个数量会返回429。默认值为100（100个请求）。示例值：1（1个请求）